### PR TITLE
Bug Fix for when password.length > 64

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -306,7 +306,11 @@ function run(
 
 	function PBKDF2_HMAC_SHA256_OneIter(password, salt, dkLen) {
 		// compress password if it's longer than hash block length
-		password = password.length <= 64 ? password : SHA256(password);
+		if(password.length > 64)
+		{
+			// coerces the structure into an array type if it lacks support for the .push operation 
+			password = SHA256(password.push ? password : [...password])
+		}
 
 		let i,
 			innerLen = 64 + salt.length + 4,


### PR DESCRIPTION
This is a slight issue inherited from scrypt-async-js, 

The SHA-256 method is expecting an array-like structure that supports the .push method, so if it receives a Buffer or Uint8Array (which is supported in your documentation) with a length greater than 64, the program will throw an exception. 

This patch should fix that.